### PR TITLE
fix(octokit): trying a diff auth method for octokit

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ if (!allowed.includes(github.context.eventName)) {
 const options = config({ workspace, path: inputs.config })
 
 // init octokit
-const octokit = github.getOctokit(inputs.token)
+const octokit = github.getOctokit(null, { auth: inputs.token })
 
 // get dependant repos
 const repositories = await repos(octokit, options)


### PR DESCRIPTION
@actions/github uses @octokit/core https://github.com/actions/toolkit/blob/main/packages/github/src/utils.ts#L5

@octokit/core docs mention this way of authentication https://github.com/octokit/core.js?tab=readme-ov-file#authentication

if we pass it this way it should be picked up instead of `token` https://github.com/actions/toolkit/blob/main/packages/github/src/internal/utils.ts#L16